### PR TITLE
Add OCP 4.2 new global catalog namespace section

### DIFF
--- a/docs/openshift/important-changes-by-release.md
+++ b/docs/openshift/important-changes-by-release.md
@@ -1,0 +1,7 @@
+# Important Changes by OCP Release
+
+## 4.2
+
+### New Global Catalog Namespace
+
+The default _GCN_ (global catalog namespace) has been changed from OLM's namespace, `openshift-operator-lifecycle-manager`, to `operator-marketplace`. As a quick refresher, the GCN is a special namespace that contains operator catalogs that can be subscribed to from any namespace in the cluster. The important positive implication of this change is that default catalogs in the `operator-marketplace` namespace (`redhat-operators`, `certified-operators`, etc...) can be subscribed to from all namespaces without further configuration. The negative implication is that any subscriptions to catalogs in the `openshift-operator-lifecycle-manager` namespace must be co-located in that namespace.

--- a/index.md
+++ b/index.md
@@ -54,3 +54,7 @@
 - [When and how should a running Operator express that it is not upgradeable?](https://)
 - [When should an Operator upgrade its Operands?](https://)
 - [How should an Operator Author create and package an Operator for a singleton operand?](https://)
+
+## OLM on OCP (OpenShift Container Platform)
+
+- [Important changes by OCP release](docs/openshift/important-changes-by-release.md)

--- a/index.md
+++ b/index.md
@@ -1,58 +1,56 @@
-Operator Lifecycle Book
-===
+# Operator Lifecycle Book
 
+- [Introduction](https://operator-framework.github.io/olm-book/docs/intro)
 
- - [Introduction](https://operator-framework.github.io/olm-book/docs/intro)
- 
-# Foundational Concepts
+## Foundational Concepts
 
- - [What is an Operator?](https://operator-framework.github.io/olm-book/docs/what-is-an-operator)
- - [Why would I use OLM?](test)
- - [What does OLM enable?](https://operator-framework.github.io/olm-book/docs/what-does-olm-enable)
- - [Operators on cluster](test)
+- [What is an Operator?](https://operator-framework.github.io/olm-book/docs/what-is-an-operator)
+- [Why would I use OLM?](test)
+- [What does OLM enable?](https://operator-framework.github.io/olm-book/docs/what-does-olm-enable)
+- [Operators on cluster](test)
 
-# Under the hood
+## Under the hood
 
- - [Operands](test)
- - [Operator bundles](test)
- - [Operator catalogs](test)
- - [Subscriptions](test)
- - [Operator dependencies and requirements](test)
- - [Operator update graphs and channels](test)
- - [Operator versioning and release strategies](test)
- - [Operand support matrices](test)
- - [Operator install modes](test)
- - [Operator scoping](test)
+- [Operands](test)
+- [Operator bundles](test)
+- [Operator catalogs](test)
+- [Subscriptions](test)
+- [Operator dependencies and requirements](test)
+- [Operator update graphs and channels](test)
+- [Operator versioning and release strategies](test)
+- [Operand support matrices](test)
+- [Operator install modes](test)
+- [Operator scoping](test)
 
-# Basic Use Cases
+## Basic Use Cases
 
 - [How do I install OLM?](https://)
- - [How do I package my Operator for OLM?](https://)
- - [How do I validate the package?](https://)
- - [How do I install my Operator with OLM?](https://)
- - [How do I make my Operator part of a catalog?](https://)
- - [How do I list Operators available to install?](https://)
- - [How do I uninstall an Operator?](https://)
- - [How do I discover the presence/availability of an Operator?](https://)
- - [How do I troubleshoot a failing installation?](https://)
- - [How do I uninstall OLM?](https://)
+- [How do I package my Operator for OLM?](https://)
+- [How do I validate the package?](https://)
+- [How do I install my Operator with OLM?](https://)
+- [How do I make my Operator part of a catalog?](https://)
+- [How do I list Operators available to install?](https://)
+- [How do I uninstall an Operator?](https://)
+- [How do I discover the presence/availability of an Operator?](https://)
+- [How do I troubleshoot a failing installation?](https://)
+- [How do I uninstall OLM?](https://)
 
-# Advanced Use Cases
+## Advanced Use Cases
 
- - [When do I need to update my Operator?](https://)
- - [How do I create an updated version of my Operator?](https://)
- - [How do I test an update before shipping?](https://)
- - [How do I ship an updated version of my Operator?](https://)
- - [How do I approve an update?](https://)
- - [How do I scope down an Operator?](https://)
- - [How can I install an Operator when I am not cluster admin?](https://)
- - [How do I rely on other Operators with my Operator?](https://)
- - [How can I configure / customize my Operator deployment?](https://)
- - [How can I set / override defaults to amend runtime behavior of my Operator?](https://)
- - [What annotations can I use to drive UIs?](https://)
- - [How do I change which users are able to use an Operator?](https://)
- - [How do I “hide” particular CRDs not intended for consumption by an end-user?](https://)
- - [How do I ship webhooks?](https://)
- - [When and how should a running Operator express that it is not upgradeable?](https://)
- - [When should an Operator upgrade its Operands?](https://)
- - [How should an Operator Author create and package an Operator for a singleton operand?](https://)
+- [When do I need to update my Operator?](https://)
+- [How do I create an updated version of my Operator?](https://)
+- [How do I test an update before shipping?](https://)
+- [How do I ship an updated version of my Operator?](https://)
+- [How do I approve an update?](https://)
+- [How do I scope down an Operator?](https://)
+- [How can I install an Operator when I am not cluster admin?](https://)
+- [How do I rely on other Operators with my Operator?](https://)
+- [How can I configure / customize my Operator deployment?](https://)
+- [How can I set / override defaults to amend runtime behavior of my Operator?](https://)
+- [What annotations can I use to drive UIs?](https://)
+- [How do I change which users are able to use an Operator?](https://)
+- [How do I “hide” particular CRDs not intended for consumption by an end-user?](https://)
+- [How do I ship webhooks?](https://)
+- [When and how should a running Operator express that it is not upgradeable?](https://)
+- [When should an Operator upgrade its Operands?](https://)
+- [How should an Operator Author create and package an Operator for a singleton operand?](https://)


### PR DESCRIPTION
This is my crack at adding a structure for OpenShift specific docs and a section on the 4.2 change to `openshift-marketplace` as the global catalog namespace change.