### PR TITLE
Add documentation on how to uninstall an Operator

### DIFF
--- a/docs/uninstall-an-operator.md
+++ b/docs/uninstall-an-operator.md
@@ -5,7 +5,7 @@ In order to uninstall an operator, you need to delete the following resources:
 - Subscription
 - ClusterServiceVersion (CSV)
 
-Both `Subscription` and `ClusterServiceVersion` are namespace objects meaning you need to delete a `Subscription` and a `CSV` in a specific namespace where you install the operator into.
+Both `Subscription` and `CSV` are namespaced objects meaning you need to delete a `Subscription` and a `CSV` in a specific namespace where you install the operator into.
 
 ## Delete a Subscription
 
@@ -33,4 +33,4 @@ You can delete the `ClusterServiceVersion` in the namespace that the operator wa
 $ kubectl delete clusterserviceversion <csv-name> -n <namespace>
 ```
 
-By deleting `ClusterServiceVersion`, it will delete the operator's resources that OLM created for the operator such as deployment, pod(s), RBAC, and others. This also deletes any corresponding CSVs that OLM "Copied" into other namespaces watched by the operator.
+By deleting `ClusterServiceVersion`, it will delete the operator's resources that OLM created for the operator such as deployment, pod(s), RBAC, and others. However, `CustomResourceDefinition` (CRD), that is installed by the operator, won't get deleted during uninstalling process. Deleting `CRD` will resolve into deleting all instances of that `CRD` which may be used by other operators. `CRD` can be deleted manually if needed. Furthermore, deleting a `CSV` also deletes any corresponding CSVs that OLM "Copied" into other namespaces watched by the operator.

--- a/docs/uninstall-an-operator.md
+++ b/docs/uninstall-an-operator.md
@@ -1,1 +1,36 @@
 # How to uninstall an Operator?
+
+In order to uninstall an operator, you need to delete the following resources:
+
+- Subscription
+- ClusterServiceVersion (CSV)
+
+Both `Subscription` and `ClusterServiceVersion` are namespace objects meaning you need to delete a `Subscription` and a `CSV` in a specific namespace where you install the operator into.
+
+## Delete a Subscription
+
+If you wish to look up a list of `Subscription` in a specific namespace to see which `Subscription` you want to delete, you can use the following `kubectl` command:
+```bash
+$ kubectl get subscription -n <namespace>
+```
+
+You can delete the `Subscription` in the namespace that the operator was installed into using this command:
+```bash
+$ kubectl delete subscription <subscription-name> -n <namespace>
+```
+
+## Delete a ClusterServiceVersion (CSV)
+
+If you wish to look up a list of `ClusterServiceVersion` in a specific namespace to see which `ClusterServiceVersion` you need to delete, you can use the example `kubectl` command:
+
+```bash
+$ kubectl get clusterserviceversion -n <namespace>
+```
+
+You can delete the `ClusterServiceVersion` in the namespace that the operator was installed into using this command:
+
+```bash
+$ kubectl delete clusterserviceversion <csv-name> -n <namespace>
+```
+
+By deleting `ClusterServiceVersion`, it will delete the operator's resources that OLM created for the operator such as deployment, pod(s), RBAC, and others. This also deletes any corresponding CSVs that OLM "Copied" into other namespaces watched by the operator.

--- a/docs/uninstall-an-operator.md
+++ b/docs/uninstall-an-operator.md
@@ -1,0 +1,1 @@
+# How to uninstall an Operator?

--- a/docs/uninstall-an-operator.md
+++ b/docs/uninstall-an-operator.md
@@ -34,3 +34,10 @@ $ kubectl delete clusterserviceversion <csv-name> -n <namespace>
 ```
 
 By deleting `ClusterServiceVersion`, it will delete the operator's resources that OLM created for the operator such as deployment, pod(s), RBAC, and others. However, `CustomResourceDefinition` (CRD), that is installed by the operator, won't get deleted during uninstalling process. Deleting `CRD` will resolve into deleting all instances of that `CRD` which may be used by other operators. `CRD` can be deleted manually if needed. Furthermore, deleting a `CSV` also deletes any corresponding CSVs that OLM "Copied" into other namespaces watched by the operator.
+
+Alternatively, you can delete both `Subscription` and its `CSV` using a sequence of commands:
+```bash
+$ CSV=kubectl delete subscription <subscription-name> -n <namespace> -o json | jq '.status.installedCSV'
+$ kubectl delete subscription <subscription-name> -n <namespace>
+$ kubectl delete csv $CSV -n <namespace>
+```

--- a/index.md
+++ b/index.md
@@ -31,7 +31,7 @@
 - [How do I install my Operator with OLM?](https://)
 - [How do I make my Operator part of a catalog?](https://)
 - [How do I list Operators available to install?](https://)
-- [How do I uninstall an Operator?](https://)
+- [How do I uninstall an Operator?](https://operator-framework.github.io/olm-book/docs/uninstall-an-operator/)
 - [How do I discover the presence/availability of an Operator?](https://)
 - [How do I troubleshoot a failing installation?](https://)
 - [How do I uninstall OLM?](https://)


### PR DESCRIPTION
An Operator is installed by creating a Subscription that subscribes
to a specific Operator. By deleting the subscription, all Operator
resources such as CSV will be deleted.

Signed-off-by: Vu Dinh <vdinh@redhat.com>