### PR TITLE
Explain how to add an operator to a catalog

### DIFF
--- a/docs/add-operator-catalog.md
+++ b/docs/add-operator-catalog.md
@@ -1,0 +1,62 @@
+# Adding an operator to a catalog
+
+A pre-requisite for adding an operator to a catalog is for all of the [packaging](packaging-an-operator.md) to be completed. If that hasn't been done, stop and do that first.
+
+## Creating a new bundle image manually
+
+This section contains instructions for creating a new bundle image for adding as a new standalone catalog. However, there are new and improved ways that should be used instead that are described in the [next section](#creating-a-new-registry-image). This section is recommended reading only if you wish to get a better understanding of how data in an image is read in general.
+
+### High level overview
+
+In order to describe what we're working towards, a view from the top is helpful. Essentially the manifest files will be put into a container along with a few binaries. The binaries provide the functionality to serve the manifest files over gRPC and a gRPC health probe to report the gRPC connection status to Kubernetes.
+
+Once an image is built containing the operator manifests, a `CatalogSource` can be created that tells OLM about the image. OLM will pull in metadata (over gRPC) from the image and make that information available to the [package manifest list](list-available-operators.md).
+
+### Building the bundle image manually
+
+For convienence, there is a [published image](http://quay.io/operator-framework/upstream-registry-builder) that includes the operator-registry tools for making a bundle image. These tools include the `initializer` that takes a directory of manifests and converts them into one file that is an embedded database. The other critical tool is the operator-registry server that is used to both read the database and to make it accessible over gRPC, which was also described earlier.
+
+The [Dockerfile](https://github.com/operator-framework/operator-registry/blob/f544e227bb0e549f156aae7b319aeac976756e3f/upstream-example.Dockerfile) to use looks like this:
+
+```yaml
+FROM quay.io/operator-framework/upstream-registry-builder as builder
+
+COPY manifests manifests
+RUN ./bin/initializer -o ./bundles.db
+
+FROM scratch
+COPY --from=builder /build/bundles.db /bundles.db
+COPY --from=builder /build/bin/registry-server /registry-server
+COPY --from=builder /bin/grpc_health_probe /bin/grpc_health_probe
+EXPOSE 50051
+ENTRYPOINT ["/registry-server"]
+CMD ["--database", "bundles.db"]
+```
+
+Ensure that your manifests directory is in the same directory as this file and then build with a command that resembles:
+
+`docker build -t your-bundle:latest -f upstream-example.Dockerfile .`
+
+## Creating a new registry image
+
+A registry image is a container image that contains the manifests, but uses a different format to put data into the container. Currently, the `opm` command has some alpha level functionality for generating a registry image. Note that due to this alpha status, the command line arguments are hidden from the help output of opm. One can execute `opm alpha` to see what arguments are available. In this case, the build command is the one that should be used. For example, using the manifests in the OLM repo one can generate an etcd registry image using a command similar to:
+
+`bin/opm alpha bundle build -c singlenamespace-alpha, clusterwide-alpha -e singlenamespace-alpha -d manifests/etcd/0.6.1 -p etcd -t quay.io/your/etcd-operator:v0.6.1
+
+These images end up being smaller than the previously described bundle images because no binaries are in the container, just manifest files and labels to describe its content. (On the implementation side, what ends up happening is upon detecting an image of this type an image is started with a gRPC server binary that is injected on the fly.)
+
+### Adding to an existing catalog
+
+This section describes how to add a registry image to an existing catalog image (all catalogs are backed by images that contain databases or manifest data). To be clear, bundle images can only contain manifests for one type of operator. A catalog image does not have this limitation.
+
+Here again, the `opm` tool is used for catalog image modifications.
+
+ opm index add --bundles quay.io/operator-framework/operator-bundle-prometheus:0.15.0 --from-index quay.io/operator-framework/monitoring:1.0.0 --tag quay.io/operator-framework/monitoring:1.0.1
+
+ Note that the bundle image can not be added to a catalog image, only the registry image as described in the previous section.
+
+### Adding to a new catalog
+
+This example demonstrates how to create a completely new catalog image based on the [new registry image](#creating-a-new-registry-image).
+
+opm index add --bundles quay.io/your/etcd-operator:v0.6.1 --tag your-index:v1

--- a/docs/discover-operator-presence.md
+++ b/docs/discover-operator-presence.md
@@ -1,30 +1,33 @@
 # How do I discover the presence/availability of an Operator?
 
 ## Discovering installed operators
-Checking the presence of custom installed operators in the cluster is simply a matter of checking all the 
+
+Checking the presence of custom installed operators in the cluster is simply a matter of checking all the
 `ClusterServiceVersions` (CSV) that are available in the cluster. Every  operator installed by OLM has a corresponding CSV
 associated with it that that contains all the details of the operator. Running `kubectl get csvs -A`
-would return all CSVs across all namespaces and provide a high-level view of all custom installed operators. 
+would return all CSVs across all namespaces and provide a high-level view of all custom installed operators.
 
-If the ClusterServiceVersion fails to show up or does not reach the `Succeeded` phase, please check the [troubleshooting documentation](https://) to debug your installation.  
+If the ClusterServiceVersion fails to show up or does not reach the `Succeeded` phase, please check the [troubleshooting documentation](troubleshooting.md) to debug your installation.
 
 ## Finding available operators
+
 Operators are available from a variety of sources, or catalogs. Some catalogs are bundled in the default installation of
 OLM, and there are also online catalogs of operators available to install within the cluster.  
 
 ### Installing operators from within the cluster
-A collection of operators come packaged with the default OLM installation and can be examined by querying the packageserver. 
+
+A collection of operators come packaged with the default OLM installation and can be examined by querying the packageserver.
 These operators come from the community as well as officially supported Red Hat operators. The package server is an
  [apiserver extension](https://kubernetes.io/docs/concepts/extend-kubernetes/api-extension/apiserver-aggregation/)  
 that aggregates information on all operators available to install from catalog sources in the cluster. To see available
-packages run `kubectl get packagemanifests`. 
+packages run `kubectl get packagemanifests`.
 
-To get more information about a particular operator installed within the cluster from a catalogsource, run 
-`kubectl describe packagemanifests <operator name>`. This will provide some detailed information about the operator such as 
-its intended use, applicable CRDs, and resources for support with that particular operator. 
+To get more information about a particular operator installed within the cluster from a catalogsource, run
+`kubectl describe packagemanifests <operator name>`. This will provide some detailed information about the operator such as
+its intended use, applicable CRDs, and resources for support with that particular operator.
 
-### Finding operators to install 
+### Finding operators to install
+
 A great resource to find all available operators is [OperatorHub](https://operatorhub.io/), an online catalog
 of installable operators. There are over 80 available operators available to install, with details around the installation process,
-the upgrade process, and operator support information. Installing operators from OperatorHub is seamless if OLM is installed. 
-
+the upgrade process, and operator support information. Installing operators from OperatorHub is seamless if OLM is installed.

--- a/docs/how-do-i-install-my-operator-with-olm.md
+++ b/docs/how-do-i-install-my-operator-with-olm.md
@@ -1,6 +1,7 @@
-# How do I install my operator with OLM? 
+# How do I install my operator with OLM?
 
-[Once you've made your operator available in a catalog](https://), [or you've chosen an operator from an existing catalog](https:// ), you can install your operator by creating a Subscription to a specific channel. 
+[Once you've made your operator available in a catalog](add-operator-catalog.md), [or you've chosen an operator from an existing catalog](add-operator-catalog.md), you can install your operator by creating a Subscription to a specific channel.
+
 ```yaml
 apiVersion: operators.coreos.com/v1alpha1
 kind: Subscription
@@ -12,8 +13,9 @@ spec:
   name: <name-of-your-operator>
   source: <name-of-catalog-operator-is-part-of>
   sourceNamespace: <namespace-that-has-catalog>
- ``` 
-For example, if you want to install an operator named `my-operator`, from a catalog named `my-catalog` that is in the namespace `olm`, and you want to subscribe to the channel `stable`, your subscription yaml would look like this: 
+ ```
+
+For example, if you want to install an operator named `my-operator`, from a catalog named `my-catalog` that is in the namespace `olm`, and you want to subscribe to the channel `stable`, your subscription yaml would look like this:
 
 ```yaml
 apiVersion: operators.coreos.com/v1alpha1
@@ -26,25 +28,25 @@ spec:
   name: my-operator
   source: my-catalog
   sourceNamespace: olm
- ``` 
+ ```
 
-Once you have the subscription yaml, `kubectl apply -f Subscription.yaml` to install your operator. 
+Once you have the subscription yaml, `kubectl apply -f Subscription.yaml` to install your operator.
 
 You can inspect your Subscription with `kubectl get subs <name-of-your-subscription> -n <namespace>`.
 
-To ensure the operator installed successfully, check for the ClusterServiceVersion and the operator deployment in the namespace it was installed in. 
+To ensure the operator installed successfully, check for the ClusterServiceVersion and the operator deployment in the namespace it was installed in.
 
-```
+```sh
 $ kubectl get csv -n <namespace-operator-was-installed-in>
 
 NAME                  DISPLAY          VERSION           REPLACES              PHASE
 <name-of-csv>     <operator-name>     <version>  <csv-of-previous-version>   Succeeded
 ```
-```
+
+```sh
 $ kubectl get deployments -n <namespace-operator-was-installed-in>
 NAME                         READY   UP-TO-DATE   AVAILABLE   AGE
 <name-of-your-operator>      1/1     1            1           9m48s
 ```
 
-If the ClusterServiceVersion fails to show up or does not reach the `Succeeded` phase, please check the [troubleshooting documentation](https://) to debug your installation.  
-    
+If the ClusterServiceVersion fails to show up or does not reach the `Succeeded` phase, please check the [troubleshooting documentation](troubleshooting.md) to debug your installation.  

--- a/docs/multiarch.md
+++ b/docs/multiarch.md
@@ -35,7 +35,6 @@ labels:
     operatorframework.io/os.linux: supported
 ```
 
-
 If a ClusterServiceVersion does not include an `arch` label, it is treated as if it has the following label:
 
 ```yaml
@@ -53,6 +52,6 @@ $ kubectl get packagemanifests -l operatorframework.io/os.windows=supported
 
 ## Caveats
 
-Only the labels on the [HEAD of the default channel](./docs/glossary.html#channel-head) are considered for filtering PackageManifests by label.
+Only the labels on the [HEAD of the default channel](glossary.md#channel-head) are considered for filtering PackageManifests by label.
 
 This means, for example, that providing an alternate architecture for an operator in the non-default channel is possible, but will not be available for filtering in the PackageManifest API.

--- a/docs/operator-scoping.md
+++ b/docs/operator-scoping.md
@@ -147,7 +147,7 @@ spec:
 
 Any operator tied to this `OperatorGroup` will now be confined to the permission(s) granted to the specified `ServiceAccount`. If the operator asks for permission(s) that are outside the scope of the `ServiceAccount` the install will fail with appropriate error(s).
 
-An example of scoping an operator can be found [here]("https://operator-framework.github.io/olm-book/docs/how-do-i-scope-down-an-operator).
+An example of scoping an operator can be found [here](operator-scoping.md)
 
 ### Configuring the End User Experience
 

--- a/docs/packaging-an-operator.md
+++ b/docs/packaging-an-operator.md
@@ -17,7 +17,7 @@ This is all in service of ensuring that when a user installs an operator from OL
 
 ### Starting from an existing set of operator manifests
 
-For this example, we'll use the example manifests from [the example memcached operator](https://github.com/operator-framework/operator-sdk-samples/tree/master/memcached-operator/deploy).
+For this example, we'll use the example manifests from [the example memcached operator](https://github.com/operator-framework/operator-sdk-samples/tree/master/go/memcached-operator/deploy).
 
 These manifests consist of:
 
@@ -57,7 +57,7 @@ Most of these fields are optional, but they provide an opportunity to describe y
 
 #### Installation Metadata (Required)
 
-The next section to add to the CSV is the Install Strategy - this tells OLM about the runtime components of your operator and their requirements. 
+The next section to add to the CSV is the Install Strategy - this tells OLM about the runtime components of your operator and their requirements.
 
 Here is an example of the basic structure of an install strategy:
 
@@ -74,7 +74,7 @@ spec:
     # spec for the deployment strategy is a list of deployment specs and required permissions - similar to a pod template used in a deployment
     spec:
       permissions:
-      - serviceAccountName: memcached-operator 
+      - serviceAccountName: memcached-operator
         rules:
         - apiGroups:
           - ""
@@ -85,7 +85,7 @@ spec:
           # the rest of the rules
       # permissions required at the cluster scope
       clusterPermissions:
-      - serviceAccountName: memcached-operator 
+      - serviceAccountName: memcached-operator
         rules:
         - apiGroups:
           - ""
@@ -111,7 +111,7 @@ kind: ClusterServiceVersion
 metadata:
   name: memcached-operator.v0.10.0
 spec:
-  # ... 
+  # ...
   installModes:
   - supported: true
     type: OwnNamespace
@@ -125,7 +125,7 @@ spec:
 
 **Using `faq` to build an install strategy from an existing deployment and rbac**
 
-`faq` is a wrapper around `jq` that can handle multiple input and output formats, like the yaml we're working with now. The following example requires that [faq be installed](https://github.com/jzelinskie/faq#installation) and references [the example memcached operator](https://github.com/operator-framework/operator-sdk-samples/tree/master/memcached-operator/deploy).
+`faq` is a wrapper around `jq` that can handle multiple input and output formats, like the yaml we're working with now. The following example requires that [faq be installed](https://github.com/jzelinskie/faq#installation) and references [the example memcached operator](https://github.com/operator-framework/operator-sdk-samples/tree/master/go/memcached-operator/deploy).
 
 Here is a simple `faq` script that can generate an install strategy from a single deployment:
 
@@ -141,7 +141,7 @@ $ faq -f yaml -o yaml --slurp '.[0].spec.install = {strategy: "deployment", spec
 
 #### Defining APIs (Required)
 
-By definition, operators are programs that can talk to the Kubernetes API. Often, they are also programs that *extend* the Kubernetes API, by providing an interface via `CustomResourceDefinition`s or, less frequently, `APIService`s. 
+By definition, operators are programs that can talk to the Kubernetes API. Often, they are also programs that *extend* the Kubernetes API, by providing an interface via `CustomResourceDefinition`s or, less frequently, `APIService`s.
 
 ##### Owned APIs
 
@@ -153,10 +153,10 @@ kind: ClusterServiceVersion
 metadata:
   name: memcached-operator.v0.10.0
 spec:
-  # ... 
+  # ...
   customresourcedefinitions:
     owned:
-    # a list of CRDs that this operator owns 
+    # a list of CRDs that this operator owns
       # name is the metadata.name of the CRD
     - name: cache.example.com
       # version is the version of the CRD (one per entry)
@@ -175,7 +175,7 @@ kind: ClusterServiceVersion
 metadata:
   name: other-operator.v1.0
 spec:
-  # ... 
+  # ...
   customresourcedefinitions:
     required:
     # a list of CRDs that this operator requires
@@ -192,10 +192,10 @@ kind: ClusterServiceVersion
 metadata:
   name: memcached-operator.v0.10.0
 spec:
-  # ... 
+  # ...
   customresourcedefinitions:
     owned:
-    # a list of CRDs that this operator owns 
+    # a list of CRDs that this operator owns
       # name is the metadata.name of the CRD
     - name: cache.example.com
       # version is the version of the CRD (one per entry)
@@ -222,7 +222,7 @@ spec:
     kind: Pod
 ```
 
-The absence of any required `nativeAPIs` from a cluster will pause the installation of the operator, and `OLM` will write a status into the `CSV` indicating the missing APIs. 
+The absence of any required `nativeAPIs` from a cluster will pause the installation of the operator, and `OLM` will write a status into the `CSV` indicating the missing APIs.
 
 TODO: example status
 

--- a/docs/snapshot-appr-registry.md
+++ b/docs/snapshot-appr-registry.md
@@ -17,7 +17,7 @@ As of OCP 4.3, Red Hat provided operators are distributed via appr catalogs. Cre
 ## Prerequisites
 
 - Linux
-- A version `oc` that has the `oc catalog build`, such as [this one for OCP `4.3`](https://openshift-release-artifacts.svc.ci.openshift.org/4.3.0-0.nightly-2019-11-13-233341/openshift-client-linux-4.3.0-0.nightly-2019-11-13-233341.tar.gz)
+- A version `oc` that has the `oc catalog build`, such as this one for OCP `4.3`: https://openshift-release-artifacts.svc.ci.openshift.org/4.3.0-0.nightly-2019-11-13-233341/openshift-client-linux-4.3.0-0.nightly-2019-11-13-233341.tar.gz
 - A container image registry that supports [Docker v2-2](https://docs.docker.com/registry/spec/manifest-v2-2/)
 - [grpcurl](https://github.com/fullstorydev/grpcurl) (optional, for testing)
 

--- a/docs/when-to-update-my-operator.md
+++ b/docs/when-to-update-my-operator.md
@@ -23,4 +23,5 @@ For example:
 $ kubectl delete pods -n olm -l olm.catalogSource=operatorhubio-catalog
 
 ```
-The operators that were installed from the catalog will be updated automatically or manually, depending on the value of `installPlanApproval` in the Subscription for the operator. For more information on approving manual updates to operators, please see [How do I approve an update?](docs/)   
+
+The operators that were installed from the catalog will be updated automatically or manually, depending on the value of `installPlanApproval` in the Subscription for the operator. <!-- For more information on approving manual updates to operators, please see [How do I approve an update?](docs/) -->

--- a/index.md
+++ b/index.md
@@ -57,6 +57,7 @@
 - [How should an Operator Author create and package an Operator for a singleton operand?](docs/)
 - [How do I snapshot a Quay Appregistry operator catalog?](docs/snapshot-appr-registry.md)
 - [How do I ship an operator that supports multiple node architectures?](docs/multiarch.md)
+- [How do I add an operator to a catalog?](docs/add-operator-catalog.md)
 
 ## Troubleshooting
 


### PR DESCRIPTION
I've documented both the old way and the new index based ways. I was assuming that documenting the "old" way is useful. Also, for better or worse, I think I've invented some new terminology:

Bundle image - the old way, an image that contains manifests that are stored in a sqlite database (in the text I specifically said embedded instead) that is served by a binary that reads that data and serves it
Registry image - this is an image that contains the manifests in a scratch image, specifically for one operator
Catalog image - this is an image of one or many registry images

Perhaps these are not welcome/correct definitions and if so the text needs to be updated.

A lot of the content here was pulled from https://github.com/operator-framework/operator-registry/blob/master/docs/design/operator-bundle.md and https://github.com/operator-framework/operator-registry/blob/master/docs/design/opm-tooling.md.