### PR TITLE
How to identify that new updates are available

### DIFF
--- a/docs/snapshot-appr-registry.md
+++ b/docs/snapshot-appr-registry.md
@@ -17,13 +17,13 @@ As of OCP 4.3, Red Hat provided operators are distributed via appr catalogs. Cre
 ## Prerequisites
 
 - Linux
-- A version `oc` that has the `oc catalog build`, such as [this one for OCP `4.3`](https://openshift-release-artifacts.svc.ci.openshift.org/4.3/openshift-client-linux-4.3.0-0.nightly-2020-02-21-115435.tar.gz)
+- A version `oc` that has the `oc catalog build`, such as [this one for OCP `4.3`](https://openshift-release-artifacts.svc.ci.openshift.org/4.3/)
 - A container image registry that supports [Docker v2-2](https://docs.docker.com/registry/spec/manifest-v2-2/)
 - [grpcurl](https://github.com/fullstorydev/grpcurl) (optional, for testing)
 
 ## Setup
 
-Users should authenticate with the target image registry. By default, `oc adm catalog build` uses `~/.docker/config.json` to determine credentials. 
+Users should authenticate with the target image registry. By default, `oc adm catalog build` uses `~/.docker/config.json` to determine credentials.
 
 ## Taking a snapshot
 

--- a/docs/subscriptions.md
+++ b/docs/subscriptions.md
@@ -66,3 +66,7 @@ install-svojy   my-operator.v0.2.0                 Manual     false
 From here, you can approve `install-svojy` using the patch command shown earlier.
 
 With the new installPlan in the approve state, the `my-operator.v0.2.0` CSV will be deployed to the cluster and if the CSV reaches the `Succeeded` state the old CSV will be deleted. If the new CSV fails to reach the `Succeeded` state, both CSVs will continue to exist and it is up to the user to resolve the failure. In either case, OLM will not delete old installPlans as they act as a record of CSVs that were installed on your cluster.
+
+## How do I know when an update is available for an operator
+
+It is possible to identify when there is a newer version of an operator available by inspecting the status of the operator's subscription. The value associated with the `currentCSV` field is the newest version that is known to OLM, and `installedCSV` is the version that is installed on the cluster.


### PR DESCRIPTION
This commit updates the subscription.md file to includes instructions
to identify when an newer version of an operator can be installed on the
cluster.